### PR TITLE
Allow unauthenticated access to auth endpoints

### DIFF
--- a/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
@@ -29,7 +29,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.startsWith("/api/auth/");
+        // Skip JWT checks for authentication endpoints
+        return path.startsWith("/api/auth");
     }
 
     @Override

--- a/src/main/java/com/example/journalApp/security/SecurityConfig.java
+++ b/src/main/java/com/example/journalApp/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -43,6 +44,11 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers("/api/auth/**", "/health");
     }
 }
 


### PR DESCRIPTION
## Summary
- Skip JWT authentication checks for `/api/auth` endpoints
- Exclude `/api/auth/**` and `/health` from Spring Security filtering

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688f73e7b12483209a195aeb71f8d4ac