### PR TITLE
Allow unauthenticated access to auth endpoints

### DIFF
--- a/src/main/java/com/example/journalApp/controller/AuthController.java
+++ b/src/main/java/com/example/journalApp/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@CrossOrigin(origins = "*")
 public class AuthController {
 
     @Autowired

--- a/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
@@ -29,7 +29,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.startsWith("/api/auth/");
+        // Skip JWT checks for authentication endpoints
+        return path.startsWith("/api/auth");
     }
 
     @Override

--- a/src/main/java/com/example/journalApp/security/SecurityConfig.java
+++ b/src/main/java/com/example/journalApp/security/SecurityConfig.java
@@ -12,6 +12,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -23,6 +28,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**", "/health").permitAll()
                         .anyRequest().authenticated()
@@ -43,6 +49,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }
 


### PR DESCRIPTION
## Summary
- Skip JWT authentication checks for `/api/auth` endpoints
- Exclude `/api/auth/**` and `/health` from Spring Security filtering
- Enable CORS and expose authentication routes to cross-origin clients

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688f73e7b12483209a195aeb71f8d4ac