### PR TITLE
Fix misplaced public method in SecurityConfig

### DIFF
--- a/src/main/java/com/example/journalApp/security/SecurityConfig.java
+++ b/src/main/java/com/example/journalApp/security/SecurityConfig.java
@@ -14,8 +14,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-
 
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -62,10 +60,6 @@ public class SecurityConfig {
     }
 
     @Bean
-
-
-
-
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(List.of("*"));
@@ -75,12 +69,6 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-
-
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/api/auth/**", "/health");
-
-
     }
 }
 


### PR DESCRIPTION
## Summary
- remove extraneous inner public method from `SecurityConfig`
- tidy imports and close `corsConfigurationSource`

## Testing
- `./mvnw -q compile` *(fails: Non-resolvable parent POM: Could not transfer org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_688f7d612d588320b456fd6deec531b3