### PR TITLE
Secure endpoints with JWT

### DIFF
--- a/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
+++ b/src/main/java/com/example/journalApp/security/JwtAuthFilter.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collections;
 
 @Component
 public class JwtAuthFilter extends OncePerRequestFilter {
@@ -25,17 +26,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Autowired
     private UserRepository userRepo;
 
-    // ✅ This skips filtering for /api/auth/* (login/register)
+    // ✅ Skip JWT checks for authentication endpoints
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-
-        // Skip JWT checks for authentication and health endpoints
-        return path.startsWith("/api/auth") || "/health".equals(path);
-
-        // Skip JWT checks for authentication endpoints
         return path.startsWith("/api/auth");
-
     }
 
     @Override
@@ -61,10 +56,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
             if (user != null && jwtService.isTokenValid(jwt, user)) {
                 UsernamePasswordAuthenticationToken authToken =
-                        new UsernamePasswordAuthenticationToken(user, null, null);
+                        new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
 
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             }
         }

--- a/src/main/java/com/example/journalApp/security/SecurityConfig.java
+++ b/src/main/java/com/example/journalApp/security/SecurityConfig.java
@@ -7,7 +7,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -33,7 +32,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/health").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session
@@ -43,10 +42,6 @@ public class SecurityConfig {
                 .build();
     }
 
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers("/api/auth/**", "/health");
-    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {


### PR DESCRIPTION
## Summary
- Only allow unauthenticated access to `/api/auth/**`
- Enforce JWT on all other routes and fix JWT filter authority handling

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_688f85c7cf1c8320866da3fe959ffe8b